### PR TITLE
Adding support for IE9 XHR response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var LoaderText = require('./loaders/LoaderText');
 var LoaderJSON = require('./loaders/LoaderJSON');
 var LoaderVideo = require('./loaders/LoaderVideo');
 var LoaderAudio = require('./loaders/LoaderAudio');
+var LoaderCSS = require('./loaders/LoaderCSS');
 
 /**
 *
@@ -33,7 +34,8 @@ var LOADERS = {
   ogv: LoaderVideo,
   webm: LoaderVideo,
   mp3: LoaderAudio,
-  wav: LoaderAudio
+  wav: LoaderAudio,
+  css: LoaderCSS
 };
 
 /**

--- a/lib/loaders/LoaderBase.js
+++ b/lib/loaders/LoaderBase.js
@@ -271,7 +271,7 @@ var LoaderBase = new Class({
 
         case LoaderBase.typeJSON:
 
-          this.content = JSON.parse(this.xhr.response);
+          this.content = JSON.parse(this.xhr.response || this.xhr.responseText);
           break;
 
         case LoaderBase.typeDocument:

--- a/lib/loaders/LoaderBase.js
+++ b/lib/loaders/LoaderBase.js
@@ -292,7 +292,8 @@ function checkIfGoodValue () {
      this.loadType === LoaderBase.typeJSON ||
      this.loadType === LoaderBase.typeDocument ||
      this.loadType === LoaderBase.typeVideo ||
-     this.loadType === LoaderBase.typeAudio;
+     this.loadType === LoaderBase.typeAudio ||
+	  this.loadType === LoaderBase.typeCSS;;
 }
 
 function checkResponseTypeSupport () {
@@ -316,5 +317,6 @@ LoaderBase.typeJSON = 'json';
 LoaderBase.typeDocument = 'document';
 LoaderBase.typeVideo = 'video';
 LoaderBase.typeAudio = 'audio';
+LoaderBase.typeCSS = 'text';
 
 module.exports = LoaderBase;

--- a/lib/loaders/LoaderCSS.js
+++ b/lib/loaders/LoaderCSS.js
@@ -1,0 +1,33 @@
+/**
+ * This module will contain everything related to preloading.
+ *
+ * @module preloader
+ */
+var Class = require('js-oop');
+var LoaderBase = require('./LoaderBase');
+
+/**
+ * LoaderCSS will load a css file and inject into DOM.
+ *
+ * @class LoaderBase
+ * @constructor
+ * @extends {LoaderBase}
+ */
+var LoaderCSS = new Class({
+  Extends: LoaderBase,
+  initialize: function (options) {
+    Class.parent(this, LoaderBase.typeCSS, options);
+  },
+
+  _parseContent: function () {
+    if(document) {
+      var link = document.createElement('link');
+      link.href = url;
+      link.rel = 'stylesheet';
+
+      document.getElementsByTagName('head')[0].appendChild(link);
+    }
+  }
+});
+
+module.exports = LoaderCSS;

--- a/lib/loaders/LoaderCSS.js
+++ b/lib/loaders/LoaderCSS.js
@@ -22,7 +22,7 @@ var LoaderCSS = new Class({
   _parseContent: function () {
     if(document) {
       var link = document.createElement('link');
-      link.href = url;
+      link.href = this.url;
       link.rel = 'stylesheet';
 
       document.getElementsByTagName('head')[0].appendChild(link);


### PR DESCRIPTION
Preloader did not work with JSON files in IE9 due to the structure difference in XHR response object.