### PR TITLE
Adding support for IE9 XHR response

### DIFF
--- a/lib/loaders/LoaderBase.js
+++ b/lib/loaders/LoaderBase.js
@@ -271,7 +271,7 @@ var LoaderBase = new Class({
 
         case LoaderBase.typeJSON:
 
-          this.content = JSON.parse(this.xhr.response);
+          this.content = JSON.parse(this.xhr.response || this.xhr.responseText);
           break;
 
         case LoaderBase.typeDocument:


### PR DESCRIPTION
IE9 was looking for xhr.responseText instead of xhr.response.