### PR TITLE
SVG loaded with LoaderImage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ var LOADERS = {
   jpg: LoaderImage,
   jpeg: LoaderImage,
   gif: LoaderImage,
+  svg: LoaderImage,
   json: LoaderJSON,
   mp4: LoaderVideo,
   ogg: LoaderVideo,


### PR DESCRIPTION
Ideally, this could be an option if you want to load SVG as an image or as plaintext