### PR TITLE
Return the LoaderType instance from `add` methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ var Preloader = new Class({
    */
   add: function (url, options) {
     if (url) {
-      this.addFromLoaderType(url, this._getLoader(url), options);
+      return this.addFromLoaderType(url, this._getLoader(url), options);
     }
   },
 
@@ -116,7 +116,7 @@ var Preloader = new Class({
   *
   */
   addImage: function (url, options) {
-    this.addFromLoaderType(url, LoaderImage, options);
+    return this.addFromLoaderType(url, LoaderImage, options);
   },
 
   /**
@@ -128,7 +128,7 @@ var Preloader = new Class({
   *
   */
   addJSON: function (url, options) {
-    this.addFromLoaderType(url, LoaderJSON, options);
+    return this.addFromLoaderType(url, LoaderJSON, options);
   },
 
   /**
@@ -140,7 +140,7 @@ var Preloader = new Class({
   *
   */
   addText: function (url, options) {
-    this.addFromLoaderType(url, LoaderText, options);
+    return this.addFromLoaderType(url, LoaderText, options);
   },
 
   /**
@@ -152,7 +152,7 @@ var Preloader = new Class({
   *
   */
   addVideo: function (url, options) {
-    this.addFromLoaderType(url, LoaderVideo, options);
+    return this.addFromLoaderType(url, LoaderVideo, options);
   },
 
   /**
@@ -164,7 +164,7 @@ var Preloader = new Class({
   *
   */
   addAudio: function (url, options) {
-    this.addFromLoaderType(url, LoaderAudio, options);
+    return this.addFromLoaderType(url, LoaderAudio, options);
   },
 
   /**


### PR DESCRIPTION
Currently `add`, `addImage`, `addAudio`, etc. do not return the LoaderType instance that's created and returned in `addFromLoaderType`.

By returning the instance, it makes it easy to change with event callbacks like so:
```
loader
  .addImage('./test.jpg')
    .on('complete',function(){ console.log('All done with test.jpg!'); })
    .on('error',function(){ console.warn('test.jpg didn't load!'); });
```