### PR TITLE
Use LoaderImage if the extension is webp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ var LOADERS = {
   png: LoaderImage,
   jpg: LoaderImage,
   jpeg: LoaderImage,
+  webp: LoaderImage,
   gif: LoaderImage,
   json: LoaderJSON,
   mp4: LoaderVideo,


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

When loading images with `.webp`, it makes an xhr request which is not recognized by the `<img/>` tag and therefore it makes another request with the type being `WEBP`

## Solution Description

Added a new type [webp] to LOADERS that uses `LoaderImage` if the extension is `webp`

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [x] N/A

**Aditional comments:**
